### PR TITLE
rename ApiConfig property to match Client auth()

### DIFF
--- a/src/Upwork/API/Client.php
+++ b/src/Upwork/API/Client.php
@@ -107,11 +107,11 @@ class Client
         if (ApiConfig::get('mode') === 'web') {
             $aToken   = ApiConfig::get('accessToken');
             $rToken   = ApiConfig::get('refreshToken');
-            $authCode = ApiConfig::get('authCode');
+            $authzCode = ApiConfig::get('authzCode');
 
             !$aToken   || $this->_server->option('accessToken', $aToken);
             !$rToken   || $this->_server->option('refreshToken', $rToken);
-            !$authCode || $this->_server->option('authCode', $authCode);
+            !$authzCode || $this->_server->option('authzCode', $authzCode);
         }
 
         return $this->_server->auth();

--- a/src/Upwork/API/Config.php
+++ b/src/Upwork/API/Config.php
@@ -46,7 +46,7 @@ final class Config
     /**
      * @var Authorization code from authorization screen
      */
-    static private $_code;
+    static private $_authCode;
     /**
      * @var Application mode, i.e. web or nonweb
      */

--- a/src/Upwork/API/Config.php
+++ b/src/Upwork/API/Config.php
@@ -46,7 +46,7 @@ final class Config
     /**
      * @var Authorization code from authorization screen
      */
-    static private $_authCode;
+    static private $_authzCode;
     /**
      * @var Application mode, i.e. web or nonweb
      */


### PR DESCRIPTION
when using web mode, `authCode` property is requested from Api config:

https://github.com/upwork/php-upwork-oauth2/blob/b39198a5d5a1225832bbfb2910ad97c6047252a4/src/Upwork/API/Client.php#L107-L110

This throws an error, that the `authCode` property is not defined:

https://github.com/upwork/php-upwork-oauth2/blob/b39198a5d5a1225832bbfb2910ad97c6047252a4/src/Upwork/API/Config.php#L119-L125

So the property has to be renamed for the above code to work.